### PR TITLE
test(sonar): validate custom S107 rule (max=5) catches a 6-param method

### DIFF
--- a/petclinic-backend/src/main/java/victor/training/petclinic/rest/RootRestController.java
+++ b/petclinic-backend/src/main/java/victor/training/petclinic/rest/RootRestController.java
@@ -19,4 +19,14 @@ public class RootRestController {
 		response.sendRedirect(servletContextPath + "/swagger-ui/index.html");
 	}
 
+    // --- Artificial code smell to validate the customized SonarCloud rule java:S107 ---
+    // The "petclinic agentic (extend)" quality profile lowers S107's `max` parameters from 7 to 5.
+    // This method has 6 parameters, so the custom profile flags it while the default (max 7) would
+    // NOT. Temporary: remove after confirming the rule fires on SonarCloud.
+    public String describePet(String name, String type, int age, double weight,
+                              String ownerName, String city) {
+        return name + " (" + type + "), age " + age + ", " + weight + "kg — owner "
+            + ownerName + " from " + city;
+    }
+
 }


### PR DESCRIPTION
Temporary test PR to validate the customized SonarCloud Java quality profile **petclinic agentic (extend)**, which lowers rule `java:S107` ("Methods should not have too many parameters") from the default `max=7` to `max=5`.

`RootRestController.describePet(...)` has **6 parameters** — the custom profile should flag it as a code smell, whereas the built-in default (max 7) would not.

Expected: SonarCloud PR analysis reports a `java:S107` issue on the new method.

To be reverted once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)