### PR TITLE
codecity: auto-detect the change-set base (no config needed)

### DIFF
--- a/petclinic-backend/docs/scripts/codemap/README.md
+++ b/petclinic-backend/docs/scripts/codemap/README.md
@@ -71,14 +71,22 @@ The page has independent selectors for all three visual axes:
 3. **only changed** — unchanged buildings are removed from the layout entirely, so the
    treemap collapses to just the change set.
 
-What counts as "changed" (in precedence order, computed against `HEATMAP_REPO`):
+What counts as "changed" is **auto-detected** — no configuration needed (computed
+against `HEATMAP_REPO`, in precedence order):
 
-- `HEATMAP_CHANGED_BASE` set → this branch vs that base (`git diff base...HEAD`) plus any
-  uncommitted edits — the **PR** case (`HEATMAP_CHANGED_BASE=origin/main`).
-- else, uncommitted work (staged + unstaged + untracked vs `HEAD`) — *you haven't
+- On a **PR / feature branch** (there are commits ahead of the base branch) → the whole
+  branch diff `base...HEAD` plus any uncommitted edits: *everything this PR touches*. The
+  base branch is detected from `GITHUB_BASE_REF` in GitHub Actions, otherwise from the
+  remote's default branch (`origin/HEAD` → `origin/main`). Sitting **on** the base branch
+  (e.g. `main`) is not a PR.
+- else, **uncommitted work** (staged + unstaged + untracked vs `HEAD`) — *you haven't
   committed yet, so you see the files you've changed*.
-- else, the last commit (`HEAD~1..HEAD`) — *you just committed, not in a PR, so you see
-  the last commit*.
+- else, the **last commit** (`HEAD~1..HEAD`) — *you just committed, not in a PR, so you
+  see the last commit*.
+
+`HEATMAP_CHANGED_BASE` is **optional** — it only *overrides* the auto-detected base (e.g.
+to diff against a release branch instead of `main`); you never need to set it for the
+normal PR / dirty-tree / last-commit flow.
 
 When the change set is empty the highlight/hide modes are disabled and the selector
 reads "no changes".
@@ -116,7 +124,7 @@ Every script is repo-agnostic and driven by env vars (`generate.sh` sets them):
 | `HEATMAP_TITLE` / `HEATMAP_SUBTITLE` | page heading text |
 | `HEATMAP_OPEN_IN` | `vscode` / `intellij` to enable ⌘/Ctrl-click-to-open (empty = off) |
 | `HEATMAP_REPO_ABS` | absolute repo root for editor links (default: `HEATMAP_REPO`) |
-| `HEATMAP_CHANGED_BASE` | base ref for the Code City change-set filter (e.g. `origin/main` for a PR); unset = uncommitted work, else last commit |
+| `HEATMAP_CHANGED_BASE` | **optional** override of the auto-detected base ref for the change-set filter (e.g. `origin/release-1.x`); unset = auto-detect PR base → uncommitted work → last commit |
 
 ## Provenance
 

--- a/petclinic-backend/docs/scripts/codemap/render_codecity.py
+++ b/petclinic-backend/docs/scripts/codemap/render_codecity.py
@@ -58,23 +58,66 @@ def _porcelain_paths(out):
     return paths
 
 
-def _changed_files():
-    """Files in the CURRENT change set, the way a developer thinks of "what am I
-    working on right now":
+def _ref_exists(ref):
+    return bool(_run_git(["rev-parse", "--verify", "--quiet", ref]).strip())
 
-      1. HEATMAP_CHANGED_BASE set -> this branch vs that base (the PR case:
-         `git diff base...HEAD`) plus any uncommitted edits layered on top.
-      2. else, uncommitted work   -> staged + unstaged + untracked vs HEAD
-         ("you haven't committed yet: you see the files you've changed").
-      3. else, the last commit     -> HEAD~1..HEAD
-         ("you just committed, not in a PR: you see the last commit").
+
+def _current_branch():
+    return _run_git(["rev-parse", "--abbrev-ref", "HEAD"]).strip()
+
+
+def _base_branch():
+    """Auto-detect the branch this one would be a PR against, or "" if none.
+
+    - CI: GitHub Actions sets GITHUB_BASE_REF on pull_request events -> the base
+      branch, no guessing needed.
+    - Local: the remote's default branch (origin/HEAD -> origin/main), falling
+      back to the usual names.
     """
-    base = os.environ.get("HEATMAP_CHANGED_BASE", "").strip()
+    gh_base = os.environ.get("GITHUB_BASE_REF", "").strip()
+    if gh_base:
+        return next((r for r in (f"origin/{gh_base}", gh_base) if _ref_exists(r)), gh_base)
+    head = _run_git(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"]).strip()
+    if head:
+        return head.split("refs/remotes/", 1)[-1]          # e.g. "origin/main"
+    return next((r for r in ("origin/main", "origin/master", "main", "master") if _ref_exists(r)), "")
+
+
+def _pr_base():
+    """The base ref to diff against when this checkout looks like a PR / feature
+    branch (there ARE commits ahead of the base and we're NOT sitting on the base
+    branch itself), else "" so the caller falls back to working-tree / last-commit."""
+    base = _base_branch()
+    if not base:
+        return ""
+    branch = _current_branch()
+    if not branch or branch == "HEAD" or branch == base.split("/")[-1]:
+        return ""                                          # on the base branch (or detached) — not a PR
+    ahead = _run_git(["rev-list", "--count", f"{base}..HEAD"]).strip()
+    return base if ahead.isdigit() and int(ahead) > 0 else ""
+
+
+def _changed_files():
+    """Files in the CURRENT change set, auto-detecting how to read "what am I
+    working on right now" — no configuration needed:
+
+      1. On a PR / feature branch (commits ahead of the base branch, detected
+         from GITHUB_BASE_REF or origin's default branch, or forced via
+         HEATMAP_CHANGED_BASE) -> the whole branch diff `base...HEAD`, plus any
+         uncommitted edits on top. "Everything this PR touches."
+      2. else, uncommitted work -> staged + unstaged + untracked vs HEAD.
+         "You haven't committed yet: the files you've changed."
+      3. else, the last commit  -> HEAD~1..HEAD.
+         "You just committed, not in a PR: the last commit."
+
+    HEATMAP_CHANGED_BASE only overrides the auto-detected base (e.g. to diff
+    against a release branch); it is never required.
+    """
+    working = _porcelain_paths(_run_git(["status", "--porcelain"]))
+    base = os.environ.get("HEATMAP_CHANGED_BASE", "").strip() or _pr_base()
     if base:
         diff = _run_git(["diff", "--name-only", f"{base}...HEAD"])
-        files = {l.strip() for l in diff.splitlines() if l.strip()}
-        return files | _porcelain_paths(_run_git(["status", "--porcelain"]))
-    working = _porcelain_paths(_run_git(["status", "--porcelain"]))
+        return {l.strip() for l in diff.splitlines() if l.strip()} | working
     if working:
         return working
     last = {l.strip() for l in _run_git(["diff", "--name-only", "HEAD~1", "HEAD"]).splitlines() if l.strip()}

--- a/petclinic-backend/docs/scripts/codemap/test_render_codecity.py
+++ b/petclinic-backend/docs/scripts/codemap/test_render_codecity.py
@@ -175,6 +175,52 @@ class RenderCodecityTest(unittest.TestCase):
             self.assertIn('changeMode() === "hide"', html)    # "only changed" filters the dataset
             self.assertIn("THREE.BackSide", html)             # outline shell is a back-face box
 
+    def test_change_set_auto_detects_pr_branch(self):
+        """With NO config, a feature branch is recognised as a PR and its whole
+        branch diff (vs the base branch) becomes the change set."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+
+            def git(*args):
+                subprocess.run(["git", "-C", str(repo), *args], check=True,
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            git("init", "-b", "main")
+            git("config", "user.email", "t@example.com")
+            git("config", "user.name", "t")
+            src = repo / "src/main/java/app"
+            src.mkdir(parents=True)
+            (src / "Base.java").write_text("class Base {}\n")
+            git("add", "-A")
+            git("commit", "-m", "base")
+            git("checkout", "-b", "feature")               # a PR-like feature branch
+            (src / "Feature.java").write_text("class Feature {}\n")
+            git("add", "-A")
+            git("commit", "-m", "feat")
+
+            hdr = ("path\tbytes\tlines\tcommits\tbug_commits\tcommits_per_kloc\tbugs_per_kloc\t"
+                   "bugs_per_commit\tcognitive_complexity\tcomplexity_per_kloc\tfan_in\tfan_out\tcommitters\n")
+            row = lambda p: f"{p}\t100\t5\t1\t0\t0\t0\t0\t0\t0\t0\t0\t1\n"
+            tsv = repo / "codemap.tsv"
+            tsv.write_text(hdr + row("src/main/java/app/Base.java") + row("src/main/java/app/Feature.java"))
+
+            env = os.environ.copy()
+            env["HEATMAP_REPO"] = str(repo)                 # REPO_ABS -> the temp repo
+            env["HEATMAP_OUT"] = str(repo)
+            env.pop("HEATMAP_CHANGED_BASE", None)           # rely purely on auto-detection
+            env.pop("GITHUB_BASE_REF", None)
+            subprocess.run(["python3", str(SCRIPT_DIR / "render_codecity.py"), str(tsv)],
+                           check=True, cwd=str(repo), env=env)
+
+            html = (repo / "codecity.html").read_text()
+            import json
+            import re
+            files = json.loads(re.search(r"const FILES = (\[.*?\]);\nconst PACKAGES", html, re.S).group(1))
+            by_path = {f["path"]: f for f in files}
+            self.assertTrue(by_path["src/main/java/app/Feature.java"]["changed"])   # branch-only file
+            self.assertFalse(by_path["src/main/java/app/Base.java"]["changed"])     # also on the base
+            self.assertIn("const HAS_CHANGES = true", html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #44. The Code City change-set filter now **auto-detects** the PR / feature-branch case, so `HEATMAP_CHANGED_BASE` is no longer required — it only *overrides* the detected base.

### Precedence (all automatic)
1. **On a feature branch** with commits ahead of the base branch → the whole branch diff (`base...HEAD`) + uncommitted edits — *everything this PR touches*. The base is read from `GITHUB_BASE_REF` (GitHub Actions) or the remote's default branch (`origin/HEAD` → `origin/main`). Being *on* the base branch (e.g. `main`) is not a PR.
2. else **uncommitted work** (staged + unstaged + untracked vs `HEAD`).
3. else the **last commit** (`HEAD~1..HEAD`).

### Tests
Adds an integration test that spins up a throwaway repo with a base + feature branch and asserts the branch-only file is flagged `changed` with **no env vars set**. Existing render test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXpPSj59K8Z1kyNmGnwZdR)_